### PR TITLE
Catching segmentation faults on Windows, proof of concept

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,8 +88,8 @@ dependencies = [
  "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clang-sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "common-types"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity.git#0cfc6bf2a61937e639a94dbe036ebb108d329fd3"
+source = "git+https://github.com/paritytech/parity.git#25604dc5772f649b3054b887313e01b7673f460a"
 dependencies = [
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethjson 0.1.0 (git+https://github.com/paritytech/parity.git)",
@@ -225,7 +225,7 @@ dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -318,7 +318,7 @@ dependencies = [
 [[package]]
 name = "ethabi"
 version = "6.0.0"
-source = "git+https://github.com/ArtemGr/ethabi#77a9a506ca13dec75078c20d23144e672c4e193d"
+source = "git+https://github.com/artemii235/ethabi#7078a03cb1a8b6c3e7304670d7f5bf68aa250a67"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -344,7 +344,7 @@ dependencies = [
 [[package]]
 name = "ethcore-transaction"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity.git#0cfc6bf2a61937e639a94dbe036ebb108d329fd3"
+source = "git+https://github.com/paritytech/parity.git#25604dc5772f649b3054b887313e01b7673f460a"
 dependencies = [
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethjson 0.1.0 (git+https://github.com/paritytech/parity.git)",
@@ -365,7 +365,7 @@ dependencies = [
  "ethbloom 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types-serialize 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fixed-hash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "uint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "ethjson"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity.git#0cfc6bf2a61937e639a94dbe036ebb108d329fd3"
+source = "git+https://github.com/paritytech/parity.git#25604dc5772f649b3054b887313e01b7673f460a"
 dependencies = [
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -393,13 +393,13 @@ dependencies = [
 [[package]]
 name = "ethkey"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/parity.git#0cfc6bf2a61937e639a94dbe036ebb108d329fd3"
+source = "git+https://github.com/paritytech/parity.git#25604dc5772f649b3054b887313e01b7673f460a"
 dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "edit-distance 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mem 0.1.0 (git+https://github.com/paritytech/parity.git)",
  "parity-crypto 0.1.0 (git+https://github.com/ArtemGr/parity-common)",
@@ -416,7 +416,7 @@ dependencies = [
 name = "etomiclibrs"
 version = "0.1.0"
 dependencies = [
- "ethabi 6.0.0 (git+https://github.com/ArtemGr/ethabi)",
+ "ethabi 6.0.0 (git+https://github.com/artemii235/ethabi)",
  "ethcore-transaction 0.1.0 (git+https://github.com/paritytech/parity.git)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethkey 0.3.0 (git+https://github.com/paritytech/parity.git)",
@@ -424,19 +424,19 @@ dependencies = [
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.2.1 (git+https://github.com/paritytech/parity-common)",
- "web3 0.3.1 (git+https://github.com/ArtemGr/rust-web3)",
+ "web3 0.3.1 (git+https://github.com/artemii235/rust-web3)",
 ]
 
 [[package]]
 name = "evm"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity.git#0cfc6bf2a61937e639a94dbe036ebb108d329fd3"
+source = "git+https://github.com/paritytech/parity.git#25604dc5772f649b3054b887313e01b7673f460a"
 dependencies = [
  "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hash 0.1.2 (git+https://github.com/paritytech/parity-common)",
- "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-cache 0.1.0 (git+https://github.com/paritytech/parity.git)",
  "parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -510,7 +510,7 @@ name = "gstuff"
 version = "0.5.0"
 source = "git+https://github.com/ArtemGr/gstuff.rs#ab9f73e372727800b8852b65bfb17a1e5372ff29"
 dependencies = [
- "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "hashdb"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/parity-common#0045887fecd2fec39e56c962a0b27e2caf3b9474"
+source = "git+https://github.com/paritytech/parity-common#ae80aff49759515004525180c20ad322d010fa6e"
 dependencies = [
  "elastic-array 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -656,7 +656,7 @@ dependencies = [
 [[package]]
 name = "keccak-hash"
 version = "0.1.2"
-source = "git+https://github.com/paritytech/parity-common#0045887fecd2fec39e56c962a0b27e2caf3b9474"
+source = "git+https://github.com/paritytech/parity-common#ae80aff49759515004525180c20ad322d010fa6e"
 dependencies = [
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -665,7 +665,7 @@ dependencies = [
 [[package]]
 name = "keccak-hasher"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity.git#0cfc6bf2a61937e639a94dbe036ebb108d329fd3"
+source = "git+https://github.com/paritytech/parity.git#25604dc5772f649b3054b887313e01b7673f460a"
 dependencies = [
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashdb 0.2.0 (git+https://github.com/paritytech/parity-common)",
@@ -694,8 +694,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "lazycell"
@@ -762,7 +765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "mem"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity.git#0cfc6bf2a61937e639a94dbe036ebb108d329fd3"
+source = "git+https://github.com/paritytech/parity.git#25604dc5772f649b3054b887313e01b7673f460a"
 
 [[package]]
 name = "memchr"
@@ -788,7 +791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "memory-cache"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity.git#0cfc6bf2a61937e639a94dbe036ebb108d329fd3"
+source = "git+https://github.com/paritytech/parity.git#25604dc5772f649b3054b887313e01b7673f460a"
 dependencies = [
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -824,7 +827,7 @@ dependencies = [
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -853,9 +856,13 @@ dependencies = [
 name = "mm2"
 version = "0.1.0"
 dependencies = [
+ "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "bindgen 0.37.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "etomiclibrs 0.1.0",
  "gstuff 0.5.0 (git+https://github.com/ArtemGr/gstuff.rs)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -910,14 +917,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.33"
+version = "0.9.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -937,7 +944,7 @@ dependencies = [
 [[package]]
 name = "parity-bytes"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity-common#0045887fecd2fec39e56c962a0b27e2caf3b9474"
+source = "git+https://github.com/paritytech/parity-common#ae80aff49759515004525180c20ad322d010fa6e"
 
 [[package]]
 name = "parity-crypto"
@@ -993,7 +1000,7 @@ dependencies = [
 [[package]]
 name = "patricia-trie"
 version = "0.2.1"
-source = "git+https://github.com/paritytech/parity-common#0045887fecd2fec39e56c962a0b27e2caf3b9474"
+source = "git+https://github.com/paritytech/parity-common#ae80aff49759515004525180c20ad322d010fa6e"
 dependencies = [
  "elastic-array 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashdb 0.2.0 (git+https://github.com/paritytech/parity-common)",
@@ -1006,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "patricia-trie-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity.git#0cfc6bf2a61937e639a94dbe036ebb108d329fd3"
+source = "git+https://github.com/paritytech/parity.git#25604dc5772f649b3054b887313e01b7673f460a"
 dependencies = [
  "elastic-array 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1035,7 +1042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "plain_hasher"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity-common#0045887fecd2fec39e56c962a0b27e2caf3b9474"
+source = "git+https://github.com/paritytech/parity-common#ae80aff49759515004525180c20ad322d010fa6e"
 dependencies = [
  "crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1073,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1154,7 +1161,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1162,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "rlp"
 version = "0.2.1"
-source = "git+https://github.com/paritytech/parity-common#0045887fecd2fec39e56c962a0b27e2caf3b9474"
+source = "git+https://github.com/paritytech/parity-common#ae80aff49759515004525180c20ad322d010fa6e"
 dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "elastic-array 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1173,7 +1180,7 @@ dependencies = [
 [[package]]
 name = "rlp_derive"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity.git#0cfc6bf2a61937e639a94dbe036ebb108d329fd3"
+source = "git+https://github.com/paritytech/parity.git#25604dc5772f649b3054b887313e01b7673f460a"
 dependencies = [
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1208,7 +1215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1224,7 +1231,7 @@ name = "schannel"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1282,8 +1289,8 @@ version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1308,7 +1315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "slab"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1346,11 +1353,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1418,7 +1425,7 @@ name = "thread_local"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1538,7 +1545,7 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1664,13 +1671,13 @@ dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unexpected"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity.git#0cfc6bf2a61937e639a94dbe036ebb108d329fd3"
+source = "git+https://github.com/paritytech/parity.git#25604dc5772f649b3054b887313e01b7673f460a"
 
 [[package]]
 name = "unicase"
@@ -1757,7 +1764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "vm"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity.git#0cfc6bf2a61937e639a94dbe036ebb108d329fd3"
+source = "git+https://github.com/paritytech/parity.git#25604dc5772f649b3054b887313e01b7673f460a"
 dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "common-types 0.1.0 (git+https://github.com/paritytech/parity.git)",
@@ -1789,7 +1796,7 @@ dependencies = [
 [[package]]
 name = "web3"
 version = "0.3.1"
-source = "git+https://github.com/ArtemGr/rust-web3#1b49ce41a96bc94bb5ef634f1566e64a7a7cdb9d"
+source = "git+https://github.com/artemii235/rust-web3#76395bc04cc24cf8ad945bbd60cec66cfc428a01"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1922,12 +1929,12 @@ dependencies = [
 "checksum edit-distance 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3bd26878c3d921f89797a4e1a1711919f999a9f6946bb6f5a4ffda126d297b7e"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum elastic-array 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "88d4851b005ef16de812ea9acdb7bece2f0a40dd86c07b85631d7dafa54537bb"
-"checksum env_logger 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "7873e292d20e8778f951278972596b3df36ac72a65c5b406f6d4961070a870c1"
+"checksum env_logger 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)" = "f4d7e69c283751083d53d01eac767407343b8b69c4bd70058e08adc2637cb257"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)" = "<none>"
 "checksum ethabi 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05e33a914b94b763f0a92333e4e5c95c095563f06ef7d6b295b3d3c2cf31e21f"
-"checksum ethabi 6.0.0 (git+https://github.com/ArtemGr/ethabi)" = "<none>"
+"checksum ethabi 6.0.0 (git+https://github.com/artemii235/ethabi)" = "<none>"
 "checksum ethbloom 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a93a43ce2e9f09071449da36bfa7a1b20b950ee344b6904ff23de493b03b386"
 "checksum ethcore-transaction 0.1.0 (git+https://github.com/paritytech/parity.git)" = "<none>"
 "checksum ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c48729b8aea8aedb12cf4cb2e5cef439fdfe2dda4a89e47eeebd15778ef53b6"
@@ -1963,7 +1970,7 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-"checksum lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fb497c35d362b6a331cfd94956a07fc2c78a4604cdbee844a81170386b996dd3"
+"checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
@@ -1989,7 +1996,7 @@ dependencies = [
 "checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
-"checksum openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)" = "d8abc04833dcedef24221a91852931df2f63e3369ae003134e70aff3645775cc"
+"checksum openssl-sys 0.9.35 (registry+https://github.com/rust-lang/crates.io-index)" = "912f301a749394e1025d9dcddef6106ddee9252620e6d0a0e5f8d0681de9b129"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum parity-bytes 0.1.0 (git+https://github.com/paritytech/parity-common)" = "<none>"
 "checksum parity-crypto 0.1.0 (git+https://github.com/ArtemGr/parity-common)" = "<none>"
@@ -2007,7 +2014,7 @@ dependencies = [
 "checksum proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "cccdc7557a98fe98453030f077df7f3a042052fae465bb61d2c2c41435cfd9b6"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
-"checksum quote 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b71f9f575d55555aa9c06188be9d4e2bfc83ed02537948ac0d520c24d0419f1a"
+"checksum quote 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3372dc35766b36a99ce2352bd1b6ea0137c38d215cc0c8780bf6de6df7842ba9"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
@@ -2023,7 +2030,7 @@ dependencies = [
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0ceb8ce7a5e520de349e1fa172baeba4a9e8d5ef06c47471863530bc4972ee1e"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-"checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
+"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "dc1fabf2a7b6483a141426e1afd09ad543520a77ac49bd03c286e7696ccfd77f"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
@@ -2037,13 +2044,13 @@ dependencies = [
 "checksum serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c6908c7b925cd6c590358a4034de93dbddb20c45e1d021931459fd419bf0e2"
 "checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
-"checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
+"checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
 "checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
 "checksum smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "26df3bb03ca5eac2e64192b723d51f56c1b1e0860e7c766281f4598f181acdc8"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"
-"checksum syn 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4e4b5274d4a0a3d2749d5c158dc64d3403e60554dc61194648787ada5212473d"
+"checksum syn 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e13df71f29f9440b50261a5882c86eac334f1badb3134ec26f0de2f1418e44"
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
@@ -2092,7 +2099,7 @@ dependencies = [
 "checksum vm 0.1.0 (git+https://github.com/paritytech/parity.git)" = "<none>"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum want 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a05d9d966753fa4b5c8db73fcab5eed4549cfe0e1e4e66911e5564a0085c35d1"
-"checksum web3 0.3.1 (git+https://github.com/ArtemGr/rust-web3)" = "<none>"
+"checksum web3 0.3.1 (git+https://github.com/artemii235/rust-web3)" = "<none>"
 "checksum websocket 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9234b4e667c19995475227172446884f516ec0963380afa960d962ab9f4c0bfa"
 "checksum which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e84a603e7e0b1ce1aa1ee2b109c7be00155ce52df5081590d1ffb93f4f515cb2"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,14 @@ path = "iguana/exchanges/mm2.rs"
 [dependencies]
 # `etomiclibrs` pulls https://github.com/briansmith/ring, to build which on Windows we need `perl` and `yasm` in the PATH.
 # Download http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe and rename to `yasm.exe`.
+backtrace = "0.3.9"
 etomiclibrs = { path = "iguana/exchanges/etomicswap" }
+lazy_static = "1.1.0"
+winapi = "0.3.5"
 
 [build-dependencies]
 bindgen = "0.37.4"
+cc = "1.0.18"
 gstuff = { git = "https://github.com/ArtemGr/gstuff.rs" }
 
 # ring 0.12 fails to build on Windows, this patch replaces it with ring 0.13.

--- a/OSlibs/crash_reports.rs
+++ b/OSlibs/crash_reports.rs
@@ -1,0 +1,97 @@
+use backtrace;
+#[cfg(test)] use std::sync::Mutex;
+#[cfg(test)] use winapi::um::minwinbase::EXCEPTION_ACCESS_VIOLATION;
+
+type StackTrace = String;
+/// https://docs.microsoft.com/en-us/windows/desktop/debug/getexceptioncode
+#[cfg(test)] type ExceptionCode = u32;
+#[cfg(test)] lazy_static! {static ref SEH_CAUGHT: Mutex<Option<(ExceptionCode, StackTrace)>> = Mutex::new (None);}
+
+#[allow(dead_code)]
+fn stack_trace_frame (buf: &mut String, symbol: &backtrace::Symbol) {
+    let filename = match symbol.filename() {Some (path) => path, None => return};
+    let filename = match filename.components().rev().next() {Some (c) => c.as_os_str().to_string_lossy(), None => return};
+    let lineno = match symbol.lineno() {Some (lineno) => lineno, None => return};
+    let name = match symbol.name() {Some (name) => name, None => return};
+    let name = format! ("{}", name);  // NB: `fmt` is different from `SymbolName::as_str`.
+
+    // Skip common and less than informative frames.
+
+    if name.starts_with ("backtrace::") {return}
+    if name.starts_with ("core::") {return}
+    if name.starts_with ("alloc::") {return}
+    if name.starts_with ("panic_unwind::") {return}
+    if name.starts_with ("std::") {return}
+    if name.starts_with ("mm2::crash_reports::") {return}
+
+    if !buf.is_empty() {buf.push ('\n')}
+    use std::fmt::Write;
+    let _ = write! (buf, "  {}:{}] {}", filename, lineno, name);
+}
+
+/// Generates a string with the current stack trace.
+pub fn stack_trace (format: &mut FnMut (&mut String, &backtrace::Symbol)) -> StackTrace {
+    let mut buf = String::with_capacity (128);
+
+    backtrace::trace (|frame| {
+        backtrace::resolve (frame.ip(), |symbol| format (&mut buf, symbol));
+        true
+    });
+
+    buf
+}
+
+#[cfg(test)]
+#[no_mangle]
+pub extern fn rust_seh_handler (exception_code: ExceptionCode) {
+    let mut seh_caught = SEH_CAUGHT.lock().expect("!SEH_CAUGHT");
+    *seh_caught = Some ((exception_code, stack_trace(&mut stack_trace_frame)));
+}
+
+#[cfg(not(test))]
+#[no_mangle]
+pub extern fn rust_seh_handler (_exception_code: i32) {
+    println! ("SEH caught!\n");
+}
+
+#[cfg(windows)]
+#[cfg(test)]
+extern "C" {
+    fn with_seh (cb: extern fn()->());
+    fn c_access_violation();
+}
+
+#[cfg(windows)]
+#[cfg(test)]
+#[inline(never)]
+extern fn access_violation() {
+    let ptr: *mut i32 = 0 as *mut i32;
+    unsafe {*ptr = 123};
+}
+
+#[cfg(windows)]
+#[cfg(test)]
+#[inline(never)]
+extern fn call_c_access_violation() {
+    unsafe {c_access_violation()}
+}
+
+#[cfg(windows)]
+#[test]
+fn test_seh_handler() {
+    *SEH_CAUGHT.lock().expect("!SEH_CAUGHT") = None;
+    unsafe {with_seh (access_violation)};
+    let seh = SEH_CAUGHT.lock().expect("!SEH_CAUGHT").take().expect("!trace");
+    println! ("ExceptionCode: {}\n{}", seh.0, seh.1);
+    assert_eq! (seh.0, EXCEPTION_ACCESS_VIOLATION);
+    assert! (seh.1.contains ("with_seh"));
+    // SEH handler is executed by Windows after unwinding, we won't see past the `with_seh`.
+    assert! (!seh.1.contains ("access_violation"));
+
+    unsafe {with_seh (call_c_access_violation)};
+    let seh = SEH_CAUGHT.lock().expect("!SEH_CAUGHT").take().expect("!trace");
+    println! ("ExceptionCode: {}\n{}", seh.0, seh.1);
+    assert! (seh.1.contains ("with_seh"));
+    // SEH handler is executed by Windows after unwinding, we won't see past the `with_seh`.
+    assert! (!seh.1.contains ("c_access_violation"));
+}

--- a/OSlibs/win/seh.c
+++ b/OSlibs/win/seh.c
@@ -9,6 +9,13 @@ void c_access_violation()
     *ptr = 0;
 }
 
+// https://github.com/JochenKalmbach/StackWalker#displaying-the-callstack-of-an-exception
+LONG WINAPI ExpFilter(DWORD exception_code)
+{
+    rust_seh_handler (exception_code);
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+
 /// Runs the given callback withing the __try/__except block, allowing us to catch segmentation faults on Windows.
 ///
 /// Invokes `rust_seh_handler` whenever a Structured Exception is caught.
@@ -18,9 +25,7 @@ void with_seh (void (*cb)())
     {
         cb();
     }
-    __except (EXCEPTION_EXECUTE_HANDLER)
+    __except (ExpFilter(GetExceptionCode()))
     {
-        // https://docs.microsoft.com/en-us/windows/desktop/debug/getexceptioncode
-        rust_seh_handler (GetExceptionCode());
     }
 }

--- a/OSlibs/win/seh.c
+++ b/OSlibs/win/seh.c
@@ -1,0 +1,26 @@
+#include <windows.h>
+
+void rust_seh_handler (u32);
+
+void c_access_violation()
+{
+    // Straight from the https://docs.microsoft.com/en-us/windows/desktop/Debug/using-a-vectored-exception-handler.
+    char *ptr = 0;
+    *ptr = 0;
+}
+
+/// Runs the given callback withing the __try/__except block, allowing us to catch segmentation faults on Windows.
+///
+/// Invokes `rust_seh_handler` whenever a Structured Exception is caught.
+void with_seh (void (*cb)())
+{
+    __try
+    {
+        cb();
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        // https://docs.microsoft.com/en-us/windows/desktop/debug/getexceptioncode
+        rust_seh_handler (GetExceptionCode());
+    }
+}

--- a/iguana/exchanges/etomicswap/Cargo.toml
+++ b/iguana/exchanges/etomicswap/Cargo.toml
@@ -12,8 +12,8 @@ ethcore-transaction = { git = "https://github.com/paritytech/parity.git" }
 ethkey = { git = "https://github.com/paritytech/parity.git" }
 rlp = { git = "https://github.com/paritytech/parity-common" }
 ethereum-types = "0.3.1"
-web3 = { git = "https://github.com/ArtemGr/rust-web3" }
-ethabi = { git = "https://github.com/ArtemGr/ethabi" }
+web3 = { git = "https://github.com/artemii235/rust-web3" }
+ethabi = { git = "https://github.com/artemii235/ethabi" }
 hex = "0.3.2"
 regex = "1"
 libc = "0.2.42"

--- a/iguana/exchanges/mm2.rs
+++ b/iguana/exchanges/mm2.rs
@@ -19,6 +19,20 @@
 //  Copyright © 2017-2018 SuperNET. All rights reserved.
 //
 
+extern crate backtrace;
+extern crate etomiclibrs;
+
+#[allow(unused_imports)]
+#[macro_use]
+extern crate lazy_static;
+
+extern crate winapi;
+
+// Re-export preserves the functions that are temporarily accessed from C during the gradual port.
+pub use etomiclibrs::*;
+
+pub mod crash_reports {include! ("../../OSlibs/crash_reports.rs");}
+
 /* The original C code will be replaced with the corresponding Rust code in small increments,
    allowing Git history to catch up and show the function-level diffs.
 
@@ -35,8 +49,6 @@ void PNACL_message(char *arg,...)
 #include "OS_portable.h"
 #else
 */
-extern crate etomiclibrs;
-pub use etomiclibrs::*;
 
 #[allow(dead_code,non_upper_case_globals,non_camel_case_types,non_snake_case)]
 mod os_portable {include! ("../../crypto777/OS_portable.rs");}


### PR DESCRIPTION
By using a C helper with the `__try`/`__except` pair in it we're able to catch the segmentation faults and print the stack trace.

It seems that the next step should be running everything from a Rust binary in order to wrap the MarketMaker code in the Rust fault-catching machinery, and for `cargo test` to just work.