### PR TITLE
Parallel execution of MM integration tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,7 @@ cmake-build-debug
 /Dockerfile
 
 /target
+/mm2src/etomic/target
+/mm2src/helpers/target
 
 /build

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,9 +1,8 @@
 {
     "version": "0.2.0",
     "configurations": [
-
         {
-            "name": "C++ Launch (Windows)",
+            "name": "mm2",
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceRoot}/target/debug/mm2.exe",
@@ -14,10 +13,17 @@
             "externalConsole": false
         },
         {
-            "name": "C++ Attach (Windows)",
+            "name": "test-autoprice",
             "type": "cppvsdbg",
-            "request": "attach",
-            "processId": "${command:pickProcess}"
+            "request": "launch",
+            "program": "${workspaceRoot}/target/debug/mm2-6389d9eefde139e4.exe",
+            "args": ["autoprice", "--nocapture"],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}",
+            "environment": [
+                {"name": "LOCAL_THREAD_MM", "value": "1"}
+            ],
+            "externalConsole": false
         }
     ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "chrono"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "clang-sys"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,12 +557,15 @@ name = "helpers"
 version = "0.1.0"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "duct 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstuff 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -599,7 +612,7 @@ dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -622,7 +635,7 @@ dependencies = [
  "mime 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -645,7 +658,7 @@ dependencies = [
  "itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -982,16 +995,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.1.43"
+name = "num-integer"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.2"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1229,7 +1250,7 @@ dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1497,13 +1518,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.38"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1989,6 +2009,7 @@ dependencies = [
 "checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
 "checksum cexpr 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42aac45e9567d97474a834efdee3081b3c942b2205be932092f53354ce503d6c"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clang-sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7f7c04e52c35222fffcc3a115b5daf5f7e2bfb71c13c4e2321afe1fc71859c2"
 "checksum clap 2.29.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8f4a2b3bb7ef3c672d7c13d15613211d5a6976b6892c598b0fcb5d40765f19c2"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
@@ -2072,8 +2093,9 @@ dependencies = [
 "checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
+"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-"checksum num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dee092fcdf725aee04dd7da1d21debff559237d49ef1cb3e69bcb8ece44c7364"
+"checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
 "checksum openssl-sys 0.9.35 (registry+https://github.com/rust-lang/crates.io-index)" = "912f301a749394e1025d9dcddef6106ddee9252620e6d0a0e5f8d0681de9b129"
@@ -2137,7 +2159,7 @@ dependencies = [
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-"checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
+"checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e9175261fbdb60781fcd388a4d6cc7e14764a2b629a7ad94abb439aed223a44f"
 "checksum tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8ee337e5f4e501fc32966fec6fe0ca0cc1c237b0b1b14a335f8bfe3c5f06e286"
 "checksum tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"

--- a/iguana/exchanges/LP_include.h
+++ b/iguana/exchanges/LP_include.h
@@ -608,7 +608,7 @@ bits256 LP_privkey(char *symbol,char *coinaddr,uint8_t taddr);
 cJSON *LP_NXT_redeems();
 void LPinit(char* myipaddr,uint16_t myport,uint16_t mypullport,uint16_t mypubport,char *passphrase,cJSON *argjson);
 void LP_ports(uint16_t *pullportp,uint16_t *pubportp,uint16_t *busportp,uint16_t netid);
-void unbuffered_output_support();
+void unbuffered_output_support(const char* log_path);
 void LP_initcoins(void *ctx,int32_t pubsock,cJSON *coins);
 void LP_mutex_init();
 /**

--- a/iguana/exchanges/LP_portfolio.c
+++ b/iguana/exchanges/LP_portfolio.c
@@ -479,6 +479,7 @@ void LP_autoprice_iter(void *ctx,struct LP_priceinfo *btcpp)
     static cJSON *tickerjson; static uint32_t lasttime;
     char *retstr,*base,*rel; cJSON *retjson,*bid,*ask,*fundjson,*argjson; uint64_t bidsatoshis,asksatoshis; int32_t i,changed; double bidprice,askprice,bch_usd,ltc_btc,bch_btc,nxtkmd,price,factor,offset,newprice,buymargin,sellmargin,price_btc,price_usd,kmd_btc,kmd_usd; struct LP_priceinfo *kmdpp,*fiatpp,*nxtpp,*basepp,*relpp;
     printf("AUTOPRICE numautorefs.%d\n",num_LP_autorefs);
+    fflush(stdout);
     if ( (retstr= issue_curlt("https://bittrex.com/api/v1.1/public/getmarketsummaries",LP_HTTP_TIMEOUT*10)) == 0 )
     {
         printf("trex error getting marketsummaries\n");
@@ -907,7 +908,7 @@ void prices_loop(void *ctx)
         //printf("G.initializing.%d prices loop autoprices.%d autorefs.%d\n",G.initializing,LP_autoprices,num_LP_autorefs);
         if ( G.initializing != 0 )
         {
-            sleep(30);
+            sleep(1);
             continue;
         }
         LP_millistats_update(&prices_loop_stats);

--- a/iguana/exchanges/mm.c
+++ b/iguana/exchanges/mm.c
@@ -65,9 +65,27 @@ void LP_ports(uint16_t *pullportp,uint16_t *pubportp,uint16_t *busportp,uint16_t
     printf("RPCport.%d remoteport.%d, nanoports %d %d %d\n",RPC_port,RPC_port-1,*pullportp,*pubportp,*busportp);
 }
 
-/// Useful when we want to monitor the MM output closely but piped output is buffered by default.
-void unbuffered_output_support()
+/// Useful when we want to monitor the MM output closely but piped output is buffered by default.  
+/// Can also redirect the output to `log_path`, which sometimes is used in the integration tests.  
+/// Eventually we should port most of the logging to Rust and this will go away.
+void unbuffered_output_support(const char* log_path)
 {
+    if (log_path != 0)
+    {
+        if (freopen(log_path, "a", stdout) == 0)
+        {
+            printf("Can't reopen stdout to log_path %s\n", log_path);
+            abort();
+        }
+        if (freopen(log_path, "a", stderr) == 0)
+        {
+            printf("Can't reopen stderr to log_path %s\n", log_path);
+            abort();
+        }
+    }
+
+    // For some reason this doesn't work with `freopen` on Windows.
+    // TODO: Start a thread to periodically flush the streams instead.
     if (getenv("MM2_UNBUFFERED_OUTPUT") != 0)
     {
         setvbuf(stdout, 0, _IONBF, 0);

--- a/iguana/exchanges/stats.c
+++ b/iguana/exchanges/stats.c
@@ -838,6 +838,7 @@ void stats_rpcloop(void *args)
             //fcntl(bindsock, F_SETFL, fcntl(bindsock, F_GETFL, 0) | O_NONBLOCK);
 #endif
             printf(">>>>>>>>>> DEX stats %s:%d bind sock.%d DEX stats API enabled at unixtime.%u <<<<<<<<<\n",bind_on,port,bindsock,(uint32_t)time(NULL));
+            fflush(stdout);
         }
         //printf("after sock.%d\n",sock);
         clilen = sizeof(cli_addr);

--- a/mm2src/crash_reports.rs
+++ b/mm2src/crash_reports.rs
@@ -27,6 +27,7 @@ pub extern fn rust_seh_handler (exception_code: ExceptionCode) {
     *seh_caught = Some ((exception_code, trace));
 }
 
+#[cfg(windows)]
 #[allow(dead_code)]
 fn exception_name (exception_code: u32) -> &'static str {
     use winapi::um::minwinbase::{EXCEPTION_ACCESS_VIOLATION, EXCEPTION_ILLEGAL_INSTRUCTION};

--- a/mm2src/crash_reports.rs
+++ b/mm2src/crash_reports.rs
@@ -1,31 +1,12 @@
+#![allow(unused_imports)]
 use helpers::{self, stack_trace, stack_trace_frame};
-#[cfg(unix)] use std::os::raw::c_int;
+use std::os::raw::c_int;
 use std::env;
-#[allow(unused_imports)] use std::io::stderr;
-#[allow(unused_imports)] use std::io::Write;
-#[allow(unused_imports)] use std::process::abort;
+use std::io::stderr;
+use std::io::Write;
+use std::path::Path;
+use std::process::abort;
 use std::sync::Once;
-#[allow(unused_imports)] use std::sync::Mutex;
-
-#[cfg(test)] #[cfg(windows)] type StackTrace = String;
-/// https://docs.microsoft.com/en-us/windows/desktop/debug/getexceptioncode
-#[cfg(test)] #[cfg(windows)] type ExceptionCode = u32;
-#[cfg(test)] #[cfg(windows)] lazy_static! {
-    /// The testing version of `rust_seh_handler` is rigged to put the captured stack trace here.
-    static ref SEH_CAUGHT: Mutex<Option<(ExceptionCode, StackTrace)>> = Mutex::new (None);
-    /// Used to avoid the empty `SEH_CAUGHT` races.
-    static ref SEH_LOCK: Mutex<()> = Mutex::new(());
-}
-
-#[cfg(windows)]
-#[cfg(test)]
-#[no_mangle]
-pub extern fn rust_seh_handler (exception_code: ExceptionCode) {
-    let mut seh_caught = unwrap! (SEH_CAUGHT.lock(), "!SEH_CAUGHT");
-    let mut trace = String::with_capacity (4096);
-    stack_trace (&mut stack_trace_frame, &mut |l| trace.push_str (l));
-    *seh_caught = Some ((exception_code, trace));
-}
 
 #[cfg(windows)]
 #[allow(dead_code)]
@@ -41,7 +22,6 @@ fn exception_name (exception_code: u32) -> &'static str {
 
 /// Performs a crash report and aborts.
 #[cfg(windows)]
-#[cfg(not(test))]
 #[no_mangle]
 pub extern fn rust_seh_handler (exception_code: u32) {
     eprintln! ("SEH caught! ExceptionCode: {} ({}).", exception_code, exception_name (exception_code));
@@ -54,14 +34,6 @@ pub extern fn rust_seh_handler (exception_code: u32) {
     abort()
 }
 
-#[cfg(windows)]
-#[cfg(test)]
-extern "C" {fn c_access_violation();}
-
-#[cfg(windows)]
-#[cfg(test)]
-extern fn call_access_violation() {access_violation()}
-
 #[cfg(test)]
 #[inline(never)]
 fn access_violation() {
@@ -69,33 +41,9 @@ fn access_violation() {
     unsafe {*ptr = 123};
 }
 
-#[cfg(windows)]
 #[cfg(test)]
 #[inline(never)]
-extern fn call_c_access_violation() {unsafe {c_access_violation()}}
-
-#[cfg(windows)]
-#[test]
-fn test_seh_handler() {
-    use winapi::um::minwinbase::EXCEPTION_ACCESS_VIOLATION;
-
-    init_crash_reports();
-    let _seh_lock = unwrap! (SEH_LOCK.lock());
-
-    *unwrap! (SEH_CAUGHT.lock(), "!SEH_CAUGHT") = None;
-    call_access_violation();
-    let seh = unwrap! (unwrap! (SEH_CAUGHT.lock(), "!SEH_CAUGHT") .take(), "!trace");
-    println! ("ExceptionCode: {}\n{}", seh.0, seh.1);
-    assert_eq! (seh.0, EXCEPTION_ACCESS_VIOLATION);
-    assert! (seh.1.contains ("mm2::crash_reports::call_access_violation"));
-    assert! (seh.1.contains ("mm2::crash_reports::access_violation"));
-
-    call_c_access_violation();
-    let seh = unwrap! (unwrap! (SEH_CAUGHT.lock(), "!SEH_CAUGHT") .take(), "!trace");
-    println! ("ExceptionCode: {}\n{}", seh.0, seh.1);
-    assert! (seh.1.contains ("mm2::crash_reports::call_c_access_violation"));
-    assert! (seh.1.contains ("c_access_violation"));
-}
+extern fn call_access_violation() {access_violation()}
 
 #[cfg(unix)]
 extern fn signal_handler (sig: c_int) {
@@ -138,51 +86,32 @@ fn init_signal_handling() {
 fn init_signal_handling() {}
 
 /// Check that access violation stack traces are being reported to stderr under macOS and Linux.
-/// 
-/// Unix signal handling should work NP with threading. Not testing it here though,
-/// since Rust threading might not work just as well with forking. If such test is needed in the future,
-/// it should be a separate unit test and maybe with a different non-forking design.
-#[cfg(unix)]
 #[test]
-fn test_signal_handling() {
-    use nix::unistd::{dup2, fork, ForkResult};
-    use nix::sys::wait::waitpid;
-    use std::env::temp_dir;
-    use std::fs;
-    use std::io::Read;
-    use std::os::unix::io::AsRawFd;
+fn test_crash_handling() {
+    let executable = unwrap! (env::args().next());
+    let executable = unwrap! (Path::new (&executable) .canonicalize());
 
-    init_signal_handling();
-
-    let stderr_tmp_path = temp_dir().join ("test_signal_handling.stderr");
-    let _ = fs::remove_file (&stderr_tmp_path);
-    let stderr_tmp_file = unwrap! (fs::File::create (&stderr_tmp_path));
-    let stderr_tmp_fd = stderr_tmp_file.as_raw_fd();
-
-    let stderr_fd = stderr().as_raw_fd();
-
-    if let ForkResult::Parent {child} = unwrap! (fork()) {
-        println! ("Forked, child PID is {}, waiting for the child to exit...", child);
-        let wait_status = unwrap! (waitpid (child, None));
-        println! ("wait_status: {:?}", wait_status);
-        let mut stderr = String::new();
-        let mut stderr_tmp_file = unwrap! (fs::File::open (&stderr_tmp_path));
-        unwrap! (stderr_tmp_file.read_to_string (&mut stderr));
+    if env::var ("_MM2_TEST_CRASH_HANDLING_IS_CHILD") != Ok ("1".into()) {
+        println! ("test_crash_handling] Spawning a child...");
+        let output = unwrap! (cmd! (&executable, "test_crash_handling", "--nocapture")
+            .env ("_MM2_TEST_CRASH_HANDLING_IS_CHILD", "1")
+            .dir (unwrap! (executable.parent()))  // Might help finding libcurl.dll and pthreadVC2.dll.
+            .stdout_capture().stderr_capture().unchecked().run());
+        let stderr = String::from_utf8_lossy (&output.stderr);
         println! ("Obtained stderr is: ---\n{}", stderr);
-        unwrap! (fs::remove_file (&stderr_tmp_path));
-        assert! (stderr.contains ("This should go to the temporary file"));
-        assert! (stderr.contains ("Signal caught!"));
-        assert! (stderr.contains ("mm2::crash_reports::access_violation"));
-    } else {
-        println! ("Hi from the child. Redirecting stderr to {:?}.", &stderr_tmp_path);
-        unwrap! (dup2 (stderr_tmp_fd, stderr_fd));
-        {
-            let stderr = stderr();
-            let mut stderr = stderr.lock();
-            unwrap! (writeln! (&mut stderr, "This should go to the temporary file."));
-            unwrap! (stderr.flush());
+
+        if cfg!(windows) {
+          assert! (stderr.contains ("SEH caught!"));
+        } else {
+          assert! (stderr.contains ("Signal caught!"));
         }
-        access_violation();
+
+        assert! (stderr.contains ("] mm2::crash_reports::access_violation"));
+        assert! (stderr.contains ("] mm2::crash_reports::call_access_violation"));
+    } else {
+        println! ("test_crash_handling] Hi from the child.");
+        init_crash_reports();
+        call_access_violation();
     }
 }
 
@@ -201,32 +130,9 @@ pub fn init_crash_reports() {
         }
 
         // Log Rust panics.
-        // 
-        // There seems to be a conflict or a race between our crash report tracing and `RUST_BACKTRACE`.
-        // Crash reports misbehave when this option is enabled and when there are panics happening at the same time with the crash reports.
-        // A proper way to solve this would be to use our own panic handler, but this Rust feature isn't stable yet.
-        if !cfg! (test) {
-            env::set_var ("RUST_BACKTRACE", "1")
-        }
+        env::set_var ("RUST_BACKTRACE", "1")
         // ^^ NB: In the future this might also affect the normal errors, cf. https://github.com/rust-lang/rfcs/blob/master/text/2504-fix-error.md.
     })
-}
-
-/// Check that access violations are handled in a spawned thread.
-#[cfg(windows)]  // We always `abort` on UNIX, even in tests, so this particular test won't work on UNIX.
-#[test]
-fn test_crash_reports_mt() {
-    use std::thread;
-    init_crash_reports();
-    let _seh_lock = unwrap! (SEH_LOCK.lock());
-
-    *unwrap! (SEH_CAUGHT.lock(), "!SEH_CAUGHT") = None;
-    unwrap! (thread::spawn (|| {
-        access_violation()
-    }) .join(), "!join");
-    let seh = unwrap! (unwrap! (SEH_CAUGHT.lock(), "!SEH_CAUGHT") .take(), "!trace");
-    println! ("ExceptionCode: {}\n{}", seh.0, seh.1);
-    assert! (seh.1.contains ("mm2::crash_reports::access_violation"));
 }
 
 // Make sure Rust panics still work in the presence of the VEH handler.

--- a/mm2src/etomic/Cargo.toml
+++ b/mm2src/etomic/Cargo.toml
@@ -35,7 +35,7 @@ futures = "0.1"
 [build-dependencies]
 bindgen = "0.40"
 cc = "1.0"
-duct = "0.11.0"
+duct = "0.11"
 gstuff = "0.5"
 itertools = "0.7.8"
 num_cpus = "1.8.0"

--- a/mm2src/helpers/Cargo.toml
+++ b/mm2src/helpers/Cargo.toml
@@ -9,12 +9,16 @@ doctest = false
 
 [dependencies]
 backtrace = "0.3.9"
+# Using the `chrono` because the `time` formatting has serious limits, like the lack of subsecond support, IIRC.
+chrono = "0.4"
+duct = "0.11"
 futures = "0.1"
 gstuff = "0.5"
 lazy_static = "1.1.0"
 libc = "0.2"
 hyper = "0.12"
 hyper-rustls = "0.14"
+rand = "0.5"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/mm2src/helpers/helpers.rs
+++ b/mm2src/helpers/helpers.rs
@@ -353,6 +353,17 @@ pub mod for_tests {
                     let ip: IpAddr = ip.into();
                     if mm_ips.contains (&ip) {attempts += 1; continue}
                     conf["myipaddr"] = format! ("{}", ip) .into();
+
+                    if cfg! (macos) {
+                        // Make sure the local IP is enabled on MAC (and in the Travis CI).
+                        // cf. https://superuser.com/a/458877
+                        let cmd = cmd! ("sudo", "ifconfig", "lo0", "alias", format! ("{}", ip), "up");
+                        match cmd.stderr_to_stdout().read() {
+                            Err (err) => println! ("MarketMakerIt] Error trying to `up` the {}: {}", ip, err),
+                            Ok (output) => println! ("MarketMakerIt] Upped the {}: {}", ip, output)
+                        }
+                    }
+
                     break ip
                 }
             } else {  // Just use the IP given in the `conf`.

--- a/mm2src/helpers/helpers.rs
+++ b/mm2src/helpers/helpers.rs
@@ -11,6 +11,9 @@
 //!                   main
 
 extern crate backtrace;
+extern crate chrono;
+#[macro_use]
+extern crate duct;
 extern crate futures;
 #[macro_use]
 extern crate gstuff;
@@ -19,7 +22,9 @@ extern crate lazy_static;
 extern crate libc;
 extern crate hyper;
 extern crate hyper_rustls;
+extern crate rand;
 extern crate serde;
+#[macro_use]
 extern crate serde_json;
 extern crate tokio_core;
 #[macro_use]
@@ -254,4 +259,157 @@ pub fn post_json<T>(url: &str, json: String) -> Box<Future<Item=T, Error=String>
 
         Ok(result)
     }))
+}
+
+/// Helpers used in the unit and integration tests.
+pub mod for_tests {
+    use chrono::Local;
+
+    use duct::Handle;
+
+    use futures::Future;
+
+    use gstuff::{now_float, slurp};
+
+    use hyper::{Request, StatusCode};
+
+    use serde_json::{self as json, Value as Json};
+
+    use rand::{thread_rng, Rng};
+
+    use std::collections::HashSet;
+    use std::env;
+    use std::fs;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::path::{Path, PathBuf};
+    use std::str::{from_utf8, from_utf8_unchecked};
+    use std::sync::Mutex;
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    use super::slurp_req;
+
+    /// Automatically kill a wrapped process.
+    pub struct RaiiKill {handle: Handle, running: bool}
+    impl RaiiKill {
+        pub fn from_handle (handle: Handle) -> RaiiKill {
+            RaiiKill {handle, running: true}
+        }
+        pub fn running (&mut self) -> bool {
+            if !self.running {return false}
+            match self.handle.try_wait() {Ok (None) => true, _ => {self.running = false; false}}
+        }
+    }
+    impl Drop for RaiiKill {
+        fn drop (&mut self) {
+            // The cached `running` check might provide some protection against killing a wrong process under the same PID,
+            // especially if the cached `running` check is also used to monitor the status of the process.
+            if self.running() {
+                let _ = self.handle.kill();
+            }
+        }
+    }
+
+    lazy_static! {
+        /// A singleton with the IPs used by the MarketMakerIt instances created in this session.
+        static ref MM_IPS: Mutex<HashSet<IpAddr>> = Mutex::new (HashSet::new());
+    }
+
+    /// An instance of a MarketMaker process started by and for an integration test.  
+    /// Given that [in CI] the tests are executed before the build, the binary of that process is the tests binary.
+    pub struct MarketMakerIt {
+        /// The MarketMaker's current folder where it will try to open the database files.
+        pub folder: PathBuf,
+        /// Unique (to run multiple instances) IP, like "127.0.0.$x".
+        pub ip: IpAddr,
+        /// The file we redirected the standard output and error streams to.
+        pub log_path: PathBuf,
+        /// The PID of the MarketMaker process.
+        pub pc: RaiiKill,
+        /// RPC API key.
+        pub userpass: String
+    }
+    impl MarketMakerIt {
+        /// Create a new temporary directory and start a new MarketMaker process there.
+        /// 
+        /// * `conf` - The command-line configuration passed to the MarketMaker.
+        ///            Unique local IP address is injected as "myipaddr" unless this field is already present.
+        /// * `userpass` - RPC API key. We should probably extract it automatically from the MM log.
+        pub fn start (mut conf: Json, userpass: String) -> Result<MarketMakerIt, String> {
+            let executable = unwrap! (env::args().next());
+            let executable = try_s! (Path::new (&executable) .canonicalize());
+
+            let ip: IpAddr = if conf["myipaddr"].is_null() {  // Generate an unique IP.
+                let mut mm_ips = try_s! (MM_IPS.lock());
+                let mut attempts = 0;
+                let mut rng = thread_rng();
+                loop {
+                    let ip = Ipv4Addr::new (127, 0, 0, rng.gen_range (1, 255));
+                    if attempts > 128 {return ERR! ("Out of local IPs?")}
+                    let ip: IpAddr = ip.into();
+                    if mm_ips.contains (&ip) {attempts += 1; continue}
+                    conf["myipaddr"] = format! ("{}", ip) .into();
+                    break ip
+                }
+            } else {  // Just use the IP given in the `conf`.
+                let ip: IpAddr = try_s! (try_s! (conf["myipaddr"].as_str().ok_or ("myipaddr is not a string")) .parse());
+                let mut mm_ips = try_s! (MM_IPS.lock());
+                if mm_ips.contains (&ip) {println! ("MarketMakerIt] Warning, IP {} was already used.", ip)}
+                mm_ips.insert (ip.clone());
+                ip
+            };
+
+            // Use a separate (unique) temporary folder for each MM.
+            // (We could also remove the old folders after some time in order not to spam the temporary folder.
+            // Though we don't always want to remove them right away, allowing developers to check the files).
+            let now = Local::now();
+            let folder = format! ("mm2_{}_{}", now.format ("%Y-%m-%d.%H-%M-%S-%3f"), ip);
+            let folder = env::temp_dir().join (folder);
+            try_s! (fs::create_dir (&folder));
+            try_s! (fs::create_dir (folder.join ("DB")));
+            let log_path = folder.join ("mm2.log");
+
+            let pc = RaiiKill::from_handle (unwrap! (cmd! (&executable, "test_mm_start", "--nocapture")
+                .dir (&folder)
+                .env ("MM2_TEST_CONF", try_s! (json::to_string (&conf)))
+                .env ("MM2_UNBUFFERED_OUTPUT", "1")
+                .stderr_to_stdout().stdout (&log_path) .start()));
+
+            Ok (MarketMakerIt {folder, ip, log_path, pc, userpass})
+        }
+        /// Busy-wait on the log until the `pred` returns `true` or `timeout_sec` expires.
+        pub fn wait_for_log (&self, timeout_sec: f64, pred: &Fn (&str) -> bool) -> Result<(), String> {
+            let start = now_float();
+            let ms = 50 .min ((timeout_sec * 1000.) as u64 / 20 + 10);
+            loop {
+                let mm_log = slurp (&self.log_path);
+                let mm_log = unsafe {from_utf8_unchecked (&mm_log)};
+                if pred (mm_log) {return Ok(())}
+                if now_float() - start > timeout_sec {return ERR! ("Timeout expired waiting for a log condition")}
+                sleep (Duration::from_millis (ms));
+            }
+        }
+        /// Invokes the locally running MM and returns it's reply.
+        pub fn call_mm (&self, payload: Json) -> Result<(StatusCode, String), String> {
+            let payload = try_s! (json::to_string (&payload));
+            let uri = format! ("http://{}:7783", self.ip);
+            let request = try_s! (Request::builder().method ("POST") .uri (uri) .body (payload.into()));
+            let (status, _headers, body) = try_s! (slurp_req (request) .wait());
+            Ok ((status, try_s! (from_utf8 (&body)) .trim().into()))
+        }
+        /// Send the "stop" request to the locally running MM.
+        pub fn stop (&self) -> Result<(), String> {
+            let (status, body) = try_s! (self.call_mm (json! ({"userpass": self.userpass, "method": "stop"})));
+            if status != StatusCode::OK {return ERR! ("MM didn't accept a stop. body: {}", body)}
+            Ok(())
+        }
+    }
+    impl Drop for MarketMakerIt {
+        fn drop (&mut self) {
+            println! ("MarketMakerIt] drop");
+            if let Ok (mut mm_ips) = MM_IPS.lock() {
+                mm_ips.remove (&self.ip);
+            } else {println! ("MarketMakerIt] Can't lock MM_IPS.")}
+        }
+    }
 }

--- a/mm2src/helpers/helpers.rs
+++ b/mm2src/helpers/helpers.rs
@@ -354,7 +354,7 @@ pub mod for_tests {
                     if mm_ips.contains (&ip) {attempts += 1; continue}
                     conf["myipaddr"] = format! ("{}", ip) .into();
 
-                    if cfg! (macos) {
+                    if cfg! (target_os = "macos") {
                         // Make sure the local IP is enabled on MAC (and in the Travis CI).
                         // cf. https://superuser.com/a/458877
                         let cmd = cmd! ("sudo", "ifconfig", "lo0", "alias", format! ("{}", ip), "up");

--- a/mm2src/helpers/helpers.rs
+++ b/mm2src/helpers/helpers.rs
@@ -393,7 +393,7 @@ pub mod for_tests {
             }
         }
         /// Invokes the locally running MM and returns it's reply.
-        pub fn call_mm (&self, payload: Json) -> Result<(StatusCode, String), String> {
+        pub fn rpc (&self, payload: Json) -> Result<(StatusCode, String), String> {
             let payload = try_s! (json::to_string (&payload));
             let uri = format! ("http://{}:7783", self.ip);
             let request = try_s! (Request::builder().method ("POST") .uri (uri) .body (payload.into()));
@@ -402,7 +402,7 @@ pub mod for_tests {
         }
         /// Send the "stop" request to the locally running MM.
         pub fn stop (&self) -> Result<(), String> {
-            let (status, body) = try_s! (self.call_mm (json! ({"userpass": self.userpass, "method": "stop"})));
+            let (status, body) = try_s! (self.rpc (json! ({"userpass": self.userpass, "method": "stop"})));
             if status != StatusCode::OK {return ERR! ("MM didn't accept a stop. body: {}", body)}
             Ok(())
         }

--- a/mm2src/mm2.rs
+++ b/mm2src/mm2.rs
@@ -361,7 +361,7 @@ mod test {
     /// This is not a separate test but a helper used by `MarketMakerIt` to run the MarketMaker from the test binary.
     #[test]
     fn test_mm_start() {
-        if let Ok (conf) = env::var ("MM2_TEST_CONF") {
+        if let Ok (conf) = env::var ("_MM2_TEST_CONF") {
             println! ("test_mm_start] Starting the MarketMaker...");
             let conf: Json = unwrap! (json::from_str (&conf));
             let c_json = unwrap! (CString::new (unwrap! (json::to_string (&conf))));
@@ -382,7 +382,7 @@ mod test {
     }
 
     #[cfg(not(windows))]
-    fn chdir (dir: &Path) {panic! ("chdir not implemented")}
+    fn chdir (_dir: &Path) {panic! ("chdir not implemented")}
 
     /// Used by `MarketMakerIt` when the `LOCAL_THREAD_MM` env is `1`, helping debug the tested MM.
     fn local_start (folder: PathBuf, log_path: PathBuf, mut conf: Json) {
@@ -409,8 +409,9 @@ mod test {
     #[test]
     fn test_events() {
         let executable = unwrap! (env::args().next());
+        let executable = unwrap! (Path::new (&executable) .canonicalize());
         let mm_events_output = env::temp_dir().join ("test_events.mm_events.log");
-        match env::var ("MM2_TEST_EVENTS_MODE") {
+        match env::var ("_MM2_TEST_EVENTS_MODE") {
             Ok (ref mode) if mode == "MM_EVENTS" => {
                 println! ("test_events] Starting the `mm2 events`...");
                 unwrap! (events (&["_test".into(), "events".into()]));
@@ -424,7 +425,7 @@ mod test {
 
                 println! ("test_events] `mm2 events` log: {:?}.", mm_events_output);
                 let mut mm_events = RaiiKill::from_handle (unwrap! (cmd! (executable, "test_events", "--nocapture")
-                    .env ("MM2_TEST_EVENTS_MODE", "MM_EVENTS")
+                    .env ("_MM2_TEST_EVENTS_MODE", "MM_EVENTS")
                     .env ("MM2_UNBUFFERED_OUTPUT", "1")
                     .stderr_to_stdout().stdout (&mm_events_output) .start()));
 

--- a/mm2src/mm2.rs
+++ b/mm2src/mm2.rs
@@ -55,6 +55,7 @@ extern crate rand;
 
 extern crate serde;
 
+#[allow(unused_imports)]
 #[macro_use]
 extern crate serde_json;
 
@@ -283,7 +284,6 @@ mod test {
         // it should be readable, there should be enough information for both the users and the GUI to understand what's going on
         // and to make an informed decision about whether the MarketMaker is performing correctly.
 
-        // MarketMakerIt TDD.
         let mm = unwrap! (MarketMakerIt::start (
             json! ({"gui": "nogui", "client": 1, "passphrase": "123", "coins": "BTC,KMD"}),
             "5bfaeae675f043461416861c3558146bf7623526891d890dc96bc5e0e5dbc337".into()));
@@ -338,8 +338,7 @@ mod test {
 
                     mm_state = match mm_state {
                         MmState::Starting => {  // See if MM started.
-                            let mm_log = slurp (&mm.log_path);
-                            let mm_log = unsafe {from_utf8_unchecked (&mm_log)};
+                            let mm_log = unwrap! (mm.log_as_utf8());
                             let expected_bind = format! (">>>>>>>>>> DEX stats {}:7783 bind", mm.ip);
                             if mm_log.contains (&expected_bind) {MmState::Started}
                             else {MmState::Starting}
@@ -368,6 +367,7 @@ mod test {
                     };
 
                     if now_float() - started > 20. {
+                        println! ("--- mm2.log ---\n{}\n", unwrap! (mm.log_as_utf8()));
                         panic! ("Test didn't pass withing the 20 seconds timeframe. mm_state={:?}", mm_state)}
                     sleep (Duration::from_millis (20))
                 }

--- a/mm2src/seh.c
+++ b/mm2src/seh.c
@@ -15,7 +15,13 @@ long WINAPI veh_exception_filter(PEXCEPTION_POINTERS info)
 {
     // https://docs.microsoft.com/en-us/windows/desktop/debug/using-a-vectored-exception-handler
 
-    rust_seh_handler(info->ExceptionRecord->ExceptionCode);
+    DWORD code = info->ExceptionRecord->ExceptionCode;
+
+    // Don't handle the normal unwinding exceptions and panics.
+    // cf. https://blogs.msdn.microsoft.com/oldnewthing/20100730-00/?p=13273
+    if (code == 0xE06D7363) return EXCEPTION_CONTINUE_SEARCH;
+
+    rust_seh_handler(code);
 
     // These instruction skips (?) are fishy, but they're only used in crash report unit tests.
     // In a non-`test` environment `rust_seh_handler` aborts.

--- a/mm2src/seh.c
+++ b/mm2src/seh.c
@@ -3,14 +3,6 @@
 /// Performs a crash report and aborts.
 void rust_seh_handler(DWORD exception_code);
 
-/// Helps us test catching access violations happening in C code.
-void c_access_violation()
-{
-    // Straight from the https://docs.microsoft.com/en-us/windows/desktop/Debug/using-a-vectored-exception-handler.
-    char *ptr = 0;
-    *ptr = 0;
-}
-
 long WINAPI veh_exception_filter(PEXCEPTION_POINTERS info)
 {
     // https://docs.microsoft.com/en-us/windows/desktop/debug/using-a-vectored-exception-handler


### PR DESCRIPTION
With `MarketMakerIt` we can easily start a MM instance in a separate folder and on a separate local IP (except for Travis/MacOS where we don't start them in parallel because the 127.0.0.2-255 range doesn't properly work there).

Currently used in `test_events` and `test_autoprice`.